### PR TITLE
MAINT: add pandoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
         libssl-dev \
         libcurl4-openssl-dev \
         libssh2-1-dev \
+        pandoc \
         r-base-core=${R_VERSION}* \
         r-base-dev=${R_VERSION}* \
         r-recommended=${R_VERSION}*


### PR DESCRIPTION
- add pandoc to installed packages

_knitr_ and _rmarkdown_ seem to have trouble without this package.
