### PR TITLE
[CIVP-12027] upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     rm -rf ~/.cache/pip && \
     rm -f get-pip.py
 
-RUN Rscript -e "devtools::install_github('civisanalytics/civis-r', ref = 'v0.9.1', upgrade_dependencies = FALSE);"
+RUN Rscript -e "devtools::install_github('civisanalytics/civis-r', ref = 'v0.9.1', upgrade_dependencies = TRUE);"
 
 ENV VERSION=2.0.0 \
     VERSION_MAJOR=2 \


### PR DESCRIPTION
The change installs the dependencies necessary for the civis package.

This solves a problem I've been running into -- that shiny apps with library(civis) will not run.
I'm wondering why upgrade_dependencies was set to false in the first place.

