### PR TITLE
DEP update civis-r to 1.2.0 and civis-python to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
+## [2.4.0] - 2018-01-25
+
+- update civis-r to 1.2.0
+- update civis-python to 1.8.0
+
 ## [2.3.0] - 2017-11-28
 
 - Update civis-r to 1.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     rm -rf ~/.cache/pip && \
     rm -f get-pip.py
 
-RUN Rscript -e "devtools::install_github('civisanalytics/civis-r', ref = 'v1.1.1', upgrade_dependencies = FALSE);"
+RUN Rscript -e "devtools::install_github('civisanalytics/civis-r', ref = 'v1.2.0', upgrade_dependencies = FALSE);"
 
-ENV VERSION=2.3.0 \
+ENV VERSION=2.4.0 \
     VERSION_MAJOR=2 \
-    VERSION_MINOR=3 \
+    VERSION_MINOR=4 \
     VERSION_MICRO=0

--- a/requirements-python.txt
+++ b/requirements-python.txt
@@ -1,3 +1,3 @@
-civis==1.7.1
+civis==1.8.0
 pubnub==4.0.12
 joblib==0.11


### PR DESCRIPTION
This increments the version to 2.4.0, updates civis-r to 1.2.0, and civis-python to 1.8.0.