### PR TITLE
[CIVP-14923] Update rocker/verse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
+## [2.4.1] - 2018-02-19
+
+- Update rocker/verse to 3.4.3 (#21).
+
 ## [2.4.0] - 2018-01-25
 
 - update civis-r to 1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 ## [2.4.1] - 2018-02-19
 
 - Update rocker/verse to 3.4.3 (#21).
+- Update civis-python to 1.8.1 (#21).
 
 ## [2.4.0] - 2018-01-25
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:3.4.2
+FROM rocker/verse:3.4.3
 MAINTAINER support@civisanalytics.com
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
@@ -18,7 +18,7 @@ RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 
 RUN Rscript -e "devtools::install_github('civisanalytics/civis-r', ref = 'v1.2.0', upgrade_dependencies = FALSE);"
 
-ENV VERSION=2.4.0 \
+ENV VERSION=2.4.1 \
     VERSION_MAJOR=2 \
     VERSION_MINOR=4 \
-    VERSION_MICRO=0
+    VERSION_MICRO=1

--- a/requirements-python.txt
+++ b/requirements-python.txt
@@ -1,3 +1,3 @@
-civis==1.8.0
+civis==1.8.1
 pubnub==4.0.12
 joblib==0.11


### PR DESCRIPTION
This updates the version of rocker/verse to 3.4.3 in order to get the latest security patches for packages from upstream Docker images. 