### PR TITLE
TST DOC: add build time test and improve docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
+## [2.7.4] - 2018-08-14
+
+- Added build time test for `civis`.
+
+## [2.7.3] - 2018-08-13
+
+- Patch release to fix broken build, due to transient MRAN failure.
+
 ## [2.7.0] - 2018-06-21
 
 - Update civis-r to 1.5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 
 RUN Rscript -e "devtools::install_github('civisanalytics/civis-r', ref = 'v1.5.0', upgrade_dependencies = FALSE);"
 
+RUN Rscript -e "library(civis)"
+
 ENV VERSION=2.7.0 \
     VERSION_MAJOR=2 \
     VERSION_MINOR=7 \

--- a/README.md
+++ b/README.md
@@ -57,16 +57,23 @@ docker build -t datascience-r:test .
 ```
 and describe any changes in the [change log](CHANGELOG.md).
 
-## For Maintainers
+# Tag a Release
 
-This repo has autobuild enabled. Any PR that is merged to master will
-be built as the `latest` tag on Dockerhub.
-Once you are ready to create a new version, go to the "releases" tab of the repository and click
-"Draft a new release". Github will prompt you to create a new tag, release title, and release
-description. The tag should use semantic versioning in the form "vX.X.X"; "major.minor.micro".
-The title of the release should be the same as the tag. Include a change log in the release description.
-Once the release is tagged, DockerHub will automatically build three identical containers, with labels
-"major", "major.minor", and "major.minor.micro".
+To integrate with Civis Platform, the following format for releases must be followed:
+
+1. Tag: vX.X.X (major.minor.micro).
+2. Title: vX.X.X
+
+The 'Description' field is not used in Civis Platform integration, but by convention it
+should have the following format:
+
+Description: [YYYY-MM-DD] followed by summary of changes.
+
+# For Maintainers
+
+This repo has autobuild enabled. Any PR that is merged to master will be built
+as the `latest` tag on Dockerhub. Once the release is tagged, DockerHub will
+automatically build three identical containers, with labels "major", "major.minor", and "major.minor.micro".
 
 # License
 


### PR DESCRIPTION
This adds a simple build time test to make sure that `civis` gets installed correctly in the build. 

While this check is already present in the circle tests, there was an issue where a build of `latest` got triggered on dockerhub that failed to install `civis` successfully (due to a transient MRAN outage), but the build succeeded on dockerhub. This build was not covered by the tests in circle. This change would prevent that from occurring again.

In addition, the `autobuild` settings configured for this repo were incompatible with platform integration for scripts. These have been changed, and are now identical to `datascience-python`. I've altered the `README` to more strongly emphasize the required format and conventions.

I'm planning on releasing `2.7.4` with the new build test.