### PR TITLE
2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## [2.8.0] - 2019-02-12
 
-- R -> 3.5.1
+- rocker/verse -> 3.5.2
 - civis-r -> 1.6.1
 - civis-python -> 1.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
+## [2.8.0] - 2019-02-12
+
+- R -> 3.5.1
+- civis-r -> 1.6.1
+- civis-python -> 1.9.3
+
 ## [2.7.4] - 2018-08-14
 
 - Added build time test for `civis`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:3.5.0
+FROM rocker/verse:3.5.1
 MAINTAINER support@civisanalytics.com
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
@@ -16,11 +16,11 @@ RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     rm -rf ~/.cache/pip && \
     rm -f get-pip.py
 
-RUN Rscript -e "devtools::install_github('civisanalytics/civis-r', ref = 'v1.5.0', upgrade_dependencies = FALSE);"
+RUN Rscript -e "devtools::install_github('civisanalytics/civis-r', ref = 'v1.6.1', upgrade_dependencies = FALSE);"
 
 RUN Rscript -e "library(civis)"
 
-ENV VERSION=2.7.0 \
+ENV VERSION=2.8.0 \
     VERSION_MAJOR=2 \
-    VERSION_MINOR=7 \
+    VERSION_MINOR=8 \
     VERSION_MICRO=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:3.5.1
+FROM rocker/verse:3.5.2
 MAINTAINER support@civisanalytics.com
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \

--- a/requirements-python.txt
+++ b/requirements-python.txt
@@ -1,3 +1,3 @@
-civis==1.9.0
+civis==1.9.3
 pubnub==4.0.12
 joblib==0.11


### PR DESCRIPTION
- rocker/verse -> 3.5.1
- civis-r -> 1.6.1
- civis-python -> 1.9.3

Closes #29 