### PR TITLE
[CIVIS-3131] Remove R package "fst"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A micro version will increase if the only change in a release is incrementing micro versions (bugfix-only releases) on the packages contained in this image.
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
+## [5.0.0] - 2022-10-14
+
+- removed package `fst`
+
 ## [4.0.4] - 2020-04-16
 
 - rocker/verse -> 4.0.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN Rscript -e 'install.packages(readLines("requirements.txt"))'
 # install civis api client
 RUN Rscript -e 'install.packages("civis")'
 
+# rocker/verse includes "fst" which has an AGPL license
+RUN Rscript -e 'remove.packages("fst")'
+
 ENV VERSION=4.0.4 \
     VERSION_MAJOR=4 \
     VERSION_MINOR=0 \


### PR DESCRIPTION
The `fst` package is included in the base `rocker/verse` image. `fst` has an AGPL license which is problematic. This change removes the package as part of the build process.  