### PR TITLE
[CIVIS-3576] Update rocker/version and civis-python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A micro version will increase if the only change in a release is incrementing micro versions (bugfix-only releases) on the packages contained in this image.
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
+
+## [6.0.0] - 2024-08-06
+
+- rocker/verse -> 4.4.1
+- civis-python -> 2.3.0
+
 ## [5.0.0] - 2022-10-14
 
 - removed package `fst`
@@ -48,7 +54,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 - civis-python -> 1.11.0
 
 ### Added
-- added buildspecs for autobuilding and pushing Docker image to Amazon ECR 
+- added buildspecs for autobuilding and pushing Docker image to Amazon ECR
 
 ## [3.0.0] - 2019-06-21
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM rocker/verse:4.0.4
-MAINTAINER support@civisanalytics.com
+ARG BUILDPLATFORM=linux/x86_64
+FROM --platform=${BUILDPLATFORM} rocker/verse:4.4.1
+LABEL org.opencontainers.image.authors="support@civisanalytics.com"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \
@@ -21,7 +22,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
 # tuck the python client here just in case
 COPY ./requirements-python.txt /requirements-python.txt
 RUN pip3 install -r requirements-python.txt && \
-    rm -rf ~/.cache/pip    
+    rm -rf ~/.cache/pip
 
 COPY ./requirements.txt /requirements.txt
 RUN Rscript -e 'install.packages(readLines("requirements.txt"))'
@@ -32,7 +33,7 @@ RUN Rscript -e 'install.packages("civis")'
 # rocker/verse includes "fst" which has an AGPL license
 RUN Rscript -e 'remove.packages("fst")'
 
-ENV VERSION=4.0.4 \
-    VERSION_MAJOR=4 \
+ENV VERSION=6.0.0 \
+    VERSION_MAJOR=6 \
     VERSION_MINOR=0 \
-    VERSION_MICRO=4
+    VERSION_MICRO=0

--- a/requirements-python.txt
+++ b/requirements-python.txt
@@ -1,3 +1,1 @@
-cbor2==4.1.2
-pubnub>=4.5
-civis
+civis>=2.3.0,<3


### PR DESCRIPTION
This updates rocker/verse to the current latest version (4.4.1) and civis-python to 2.x.

I ran an internal test job [here](https://platform.civisanalytics.com/spa/#/scripts/containers/280435762) using an image created in an internal repository (since branches of this don't automatically build), to test that the image works in Platform.