### PR TITLE
[CIVP-9234] Fix buildspec/release.yaml

### DIFF
--- a/buildspec/release.yaml
+++ b/buildspec/release.yaml
@@ -1,4 +1,3 @@
-
 version: 0.2
 phases:
   pre_build:
@@ -13,7 +12,7 @@ phases:
       - MINOR_TAG=${PATCH_TAG%.*} # major.minor
       - MAJOR_TAG=${MINOR_TAG%.*} # major
       - >
-        docker build --target production
+        docker build
         --tag ${FIPS_REPOSITORY_URI}:${PATCH_TAG}
         --tag ${FIPS_REPOSITORY_URI}:${MINOR_TAG}
         --tag ${FIPS_REPOSITORY_URI}:${MAJOR_TAG}


### PR DESCRIPTION
This fixes an error in `buildspec/release.yaml`. I had copied the config from another repo whose Dockerfile had a "production" target and forgot to remove it in this yaml. I already removed it from the push and merge_master configs in #52.
